### PR TITLE
fixed issue with Getopt::Long eating args

### DIFF
--- a/1-integrity/CoreForeignKeys.pl
+++ b/1-integrity/CoreForeignKeys.pl
@@ -30,7 +30,7 @@ use warnings;
 use strict;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/2-integrity/AssemblyMapping.pl
+++ b/2-integrity/AssemblyMapping.pl
@@ -26,7 +26,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/2-integrity/LRG.pl
+++ b/2-integrity/LRG.pl
@@ -31,7 +31,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::DBSQL::DBAdaptor;

--- a/2-integrity/MultipleComponentAssemblyMapping.pl
+++ b/2-integrity/MultipleComponentAssemblyMapping.pl
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/2-integrity/ProjectedXrefs.pl
+++ b/2-integrity/ProjectedXrefs.pl
@@ -32,7 +32,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/2-integrity/SeqRegionCoordSystem.pl
+++ b/2-integrity/SeqRegionCoordSystem.pl
@@ -38,7 +38,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/2-integrity/SequenceLevel.pl
+++ b/2-integrity/SequenceLevel.pl
@@ -33,7 +33,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/2-integrity/XrefTypes.pl
+++ b/2-integrity/XrefTypes.pl
@@ -30,7 +30,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/3-sanity/AutoIncrement.pl
+++ b/3-sanity/AutoIncrement.pl
@@ -37,7 +37,7 @@ use Bio::EnsEMBL::Utils::SqlHelper;
 use DBUtils::Connect;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Input::AutoIncrement;
 

--- a/3-sanity/Meta.pl
+++ b/3-sanity/Meta.pl
@@ -32,7 +32,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/4-sanity/AssemblyNameLength.pl
+++ b/4-sanity/AssemblyNameLength.pl
@@ -31,7 +31,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/4-sanity/DataFiles.pl
+++ b/4-sanity/DataFiles.pl
@@ -32,7 +32,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;

--- a/5-comparison/CoordSystemAcrossSpecies.pl
+++ b/5-comparison/CoordSystemAcrossSpecies.pl
@@ -34,7 +34,7 @@ use strict;
 use warnings;
 
 use File::Spec;
-use Getopt::Long;
+use Getopt::Long qw(:config pass_through);
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::SqlHelper;


### PR DESCRIPTION
now use pass_through to keep unused arguments in @ARGV
